### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/imageclasses/Jim.cc
+++ b/src/imageclasses/Jim.cc
@@ -2605,7 +2605,7 @@ CPLErr Jim::readDataPlanes(std::vector<int> bands){
 /**
  * @param x Reported column where minimum value in image was found (start counting from 0)
  * @param y Reported row where minimum value in image was found (start counting from 0)
- * @param band Search mininum value in image for this band
+ * @param band Search minimum value in image for this band
  * @return minimum value in image for the selected band
  **/
 double Jim::getMin(int& x, int& y, int band){
@@ -2641,7 +2641,7 @@ double Jim::getMin(int& x, int& y, int band){
 /**
  * @param x Reported column where maximum value in image was found (start counting from 0)
  * @param y Reported row where maximum value in image was found (start counting from 0)
- * @param band Search mininum value in image for this band
+ * @param band Search minimum value in image for this band
  * @return maximum value in image for the selected band
  **/
 double Jim::getMax(int& x, int& y, int band){

--- a/src/imageclasses/jlann_lib.cc
+++ b/src/imageclasses/jlann_lib.cc
@@ -110,7 +110,7 @@ std::string VectorOgr::trainANN(app::AppFactory& app){
     FANN::neural_net net;//the neural network
 
     // if(model_opt.empty()){
-    //   std::string errorString="Error: filename to save model is emtpy";
+    //   std::string errorString="Error: filename to save model is empty";
     //   throw(errorString);
     // }
 

--- a/src/imageclasses/jlclassify_lib.cc
+++ b/src/imageclasses/jlclassify_lib.cc
@@ -103,7 +103,7 @@ void VectorOgr::train(app::AppFactory& app){
       throw(helpStream.str());//help was invoked, stop processing
     }
     if(model_opt.empty()){
-      std::string errorString="Error: filename to save model is emtpy";
+      std::string errorString="Error: filename to save model is empty";
       throw(errorString);
     }
     switch(getClassifier(method_opt[0])){

--- a/src/imageclasses/jlextractogr_lib.cc
+++ b/src/imageclasses/jlextractogr_lib.cc
@@ -2852,7 +2852,7 @@ CPLErr Jim::extractSample(VectorOgr& ogrWriter, AppFactory& app){
         std::cout << "out of region: " << outOfRegion << " from " << trials << " trials"<< std::endl;
       if(!ipoint){
         ostringstream ess;
-        ess << "Error: no random point created afer " << trials << " trials" << endl;
+        ess << "Error: no random point created after " << trials << " trials" << endl;
         throw(ess.str());
       }
       else if(trials>=maxTrials)

--- a/src/imageclasses/jlfilter1d_lib.cc
+++ b/src/imageclasses/jlfilter1d_lib.cc
@@ -64,7 +64,7 @@ using namespace filter;
  * @param down (type: short) (default: 1) down sampling factor. Use value 1 for no downsampling. Use value n>1 for downsampling (aggregation)
  * @param interp (type: std::string) (default: akima) type of interpolation for spectral filtering (see http://www.gnu.org/software/gsl/manual/html_node/Interpolation-Types.html)
  * @param otype (type: std::string) Data type for output image ({Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/CInt16/CInt32/CFloat32/CFloat64}). Empty string: inherit type from input image
- * @param ct (type: std::string) color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to ommit color table
+ * @param ct (type: std::string) color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to omit color table
  * @return shared pointer to image object
  **/
 
@@ -101,7 +101,7 @@ shared_ptr<Jim> Jim::filter1d(app::AppFactory& app){
  * @param down (type: short) (default: 1) down sampling factor. Use value 1 for no downsampling. Use value n>1 for downsampling (aggregation)
  * @param interp (type: std::string) (default: akima) type of interpolation for spectral filtering (see http://www.gnu.org/software/gsl/manual/html_node/Interpolation-Types.html)
  * @param otype (type: std::string) Data type for output image ({Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/CInt16/CInt32/CFloat32/CFloat64}). Empty string: inherit type from input image
- * @param ct (type: std::string) color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to ommit color table
+ * @param ct (type: std::string) color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to omit color table
  **/
 void Jim::filter1d(Jim& imgWriter, app::AppFactory& app){
   Optionjl<std::string> method_opt("f", "filter", "filter function (nvalid, median, var, min, max, sum, mean, dilate, erode, close, open, mode (majority voting), only for classes), smoothnodata (smooth nodata values only) values, ismin, ismax, order (rank pixels in order), stdev, mrf, dwt, dwti, dwt_cut, dwt_cut_from, savgolay, percentile, proportion)");
@@ -123,7 +123,7 @@ void Jim::filter1d(Jim& imgWriter, app::AppFactory& app){
   Optionjl<double> wavelengthOut_opt("wout", "wavelengthOut", "list of wavelengths in output spectrum (-wout band1 -wout band2 ...)");
   Optionjl<std::string> interpolationType_opt("interp", "interp", "type of interpolation for spectral filtering (see http://www.gnu.org/software/gsl/manual/html_node/Interpolation-Types.html)","akima");
   Optionjl<std::string>  otype_opt("ot", "otype", "Data type for output image ({Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/CInt16/CInt32/CFloat32/CFloat64}). Empty string: inherit type from input image");
-  Optionjl<std::string>  colorTable_opt("ct", "ct", "color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to ommit color table");
+  Optionjl<std::string>  colorTable_opt("ct", "ct", "color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to omit color table");
   Optionjl<short> down_opt("d", "down", "down sampling factor. Use value 1 for no downsampling. Use value n>1 for downsampling (aggregation)", 1);
   Optionjl<short> verbose_opt("v", "verbose", "verbose mode if > 0", 0,2);
 

--- a/src/imageclasses/jlfilter2d_lib.cc
+++ b/src/imageclasses/jlfilter2d_lib.cc
@@ -67,7 +67,7 @@ using namespace filter;
  * @param down (type: short) (default: 1) down sampling factor. Use value 1 for no downsampling. Use value n>1 for downsampling (aggregation)
  * @param beta (type: std::string) ASCII file with beta for each class transition in Markov Random Field
  * @param otype (type: std::string) Data type for output image ({Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/CInt16/CInt32/CFloat32/CFloat64}). Empty string: inherit type from input image
- * @param ct (type: std::string) color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to ommit color table
+ * @param ct (type: std::string) color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to omit color table
  * @param circular (type: bool) (default: 0) circular disc kernel for dilation and erosion
  * @return shared pointer to image object
  **/
@@ -99,7 +99,7 @@ shared_ptr<Jim> Jim::filter2d(const app::AppFactory& app){
  * @param down (type: short) (default: 1) down sampling factor. Use value 1 for no downsampling. Use value n>1 for downsampling (aggregation)
  * @param beta (type: std::string) ASCII file with beta for each class transition in Markov Random Field
  * @param otype (type: std::string) Data type for output image ({Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/CInt16/CInt32/CFloat32/CFloat64}). Empty string: inherit type from input image
- * @param ct (type: std::string) color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to ommit color table
+ * @param ct (type: std::string) color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to omit color table
  * @param circular (type: bool) (default: 0) circular disc kernel for dilation and erosion
  **/
 void Jim::filter2d(Jim& imgWriter, const app::AppFactory& app){
@@ -119,7 +119,7 @@ void Jim::filter2d(Jim& imgWriter, const app::AppFactory& app){
   Optionjl<bool> norm_opt("norm", "norm", "normalize tap values values when filtering",false);
   Optionjl<string> padding_opt("pad","pad", "Padding method for filtering (how to handle edge effects). Choose between: symmetric, replicate, circular, zero (pad with 0).", "symmetric");
   Optionjl<std::string>  otype_opt("ot", "otype", "Data type for output image ({Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/CInt16/CInt32/CFloat32/CFloat64}). Empty string: inherit type from input image");
-  Optionjl<string>  colorTable_opt("ct", "ct", "color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to ommit color table");
+  Optionjl<string>  colorTable_opt("ct", "ct", "color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to omit color table");
   Optionjl<short> down_opt("d", "down", "down sampling factor. Use value 1 for no downsampling. Use value n>1 for downsampling (aggregation)", 1);
   Optionjl<string> beta_opt("beta", "beta", "ASCII file with beta for each class transition in Markov Random Field");
   Optionjl<short> verbose_opt("v", "verbose", "verbose mode if > 0", 0,2);

--- a/src/imageclasses/jlfilter_lib.cc
+++ b/src/imageclasses/jlfilter_lib.cc
@@ -101,7 +101,7 @@ void Jim::filter(Jim& imgWriter, app::AppFactory& app){
   Optionjl<double> wavelengthOut_opt("wout", "wavelengthOut", "list of wavelengths in output spectrum (-wout band1 -wout band2 ...)");
   Optionjl<std::string> interpolationType_opt("interp", "interp", "type of interpolation for spectral filtering (see http://www.gnu.org/software/gsl/manual/html_node/Interpolation-Types.html)","akima");
   Optionjl<std::string>  otype_opt("ot", "otype", "Data type for output image ({Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/CInt16/CInt32/CFloat32/CFloat64}). Empty string: inherit type from input image");
-  Optionjl<string>  colorTable_opt("ct", "ct", "color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to ommit color table");
+  Optionjl<string>  colorTable_opt("ct", "ct", "color table (file with 5 columns: id R G B ALFA (0: transparent, 255: solid). Use none to omit color table");
   Optionjl<short> down_opt("d", "down", "down sampling factor. Use value 1 for no downsampling. Use value n>1 for downsampling (aggregation)", 1);
   Optionjl<string> beta_opt("beta", "beta", "ASCII file with beta for each class transition in Markov Random Field");
   // Optionjl<double> eps_opt("eps","eps", "error marging for linear feature",0);

--- a/src/imageclasses/jlpolygonize_lib.cc
+++ b/src/imageclasses/jlpolygonize_lib.cc
@@ -112,7 +112,7 @@ void Jim::polygonize(VectorOgr&ogrWriter, app::AppFactory &theApp, std::shared_p
           }
         }
         else{
-          std::string errorString="Error: clould not create memory dataset for mask datatset";
+          std::string errorString="Error: clould not create memory dataset for mask dataset";
           throw(errorString);
         }
       }
@@ -165,7 +165,7 @@ void Jim::polygonize(VectorOgr&ogrWriter, app::AppFactory &theApp, std::shared_p
         }
       }
       else{
-        std::string errorString="Error: clould not create memory dataset for input datatset";
+        std::string errorString="Error: clould not create memory dataset for input dataset";
         throw(errorString);
       }
     }

--- a/src/imageclasses/jlsml_lib.cc
+++ b/src/imageclasses/jlsml_lib.cc
@@ -103,7 +103,7 @@ void Jim::trainSML(JimList& referenceReader, app::AppFactory& app){
   try{
     // doProcess=model_opt.retrieveOption(app);
     // if(model_opt.empty()){
-    //   std::string errorString="Error: filename to save model is emtpy";
+    //   std::string errorString="Error: filename to save model is empty";
     //   throw(errorString);
     // }
     // std::ofstream outputStream(model_opt[0]);
@@ -167,7 +167,7 @@ void Jim::trainSML2d(JimList& referenceReader, app::AppFactory& app){
       throw(helpStream.str());//help was invoked, stop processing
     }
     if(model_opt.empty()){
-      std::string errorString="Error: filename to save model is emtpy";
+      std::string errorString="Error: filename to save model is empty";
       throw(errorString);
     }
     std::ofstream outputStream(model_opt[0]);

--- a/src/imageclasses/jlstretch_lib.cc
+++ b/src/imageclasses/jlstretch_lib.cc
@@ -53,7 +53,7 @@ void Jim::stretch(Jim& imgWriter, app::AppFactory& app){
   Optionjl<double> nodata_opt("nodata", "nodata", "nodata value(s) (first value will be put in output image)");
   Optionjl<double> src_min_opt("src_min","src_min","clip source below this minimum value");
   Optionjl<double> src_max_opt("src_max","src_max","clip source above this maximum value");
-  Optionjl<double> fromValue_opt("dst_min", "dst_min", "mininum value in output image", 0);
+  Optionjl<double> fromValue_opt("dst_min", "dst_min", "minimum value in output image", 0);
   Optionjl<double> toValue_opt("dst_max", "dst_max", "maximum value in output image", 255);
   Optionjl<double> minp_opt("cc_min", "cc_min", "cumulative count cut from");
   Optionjl<double> maxp_opt("cc_max", "cc_max", "cumulative count cut to");

--- a/src/imageclasses/jlsvm_lib.cc
+++ b/src/imageclasses/jlsvm_lib.cc
@@ -153,7 +153,7 @@ std::string VectorOgr::trainSVM(app::AppFactory& app){
     kernelMap["sigmoid;"]=svm::sigmoid;
 
     // if(model_opt.empty()){
-    //   std::string errorString="Error: filename to save model is emtpy";
+    //   std::string errorString="Error: filename to save model is empty";
     //   throw(errorString);
     // }
 


### PR DESCRIPTION
The lintian QA tool reported spelling errors for the Debian package build:

 * afer     -> after
 * datatset -> dataset
 * emtpy    -> empty
 * mininum  -> minimum
 * ommit    -> omit